### PR TITLE
send server name indication

### DIFF
--- a/src/main/java/me/kevinboone/jgemini/protocol/GeminiConnection.java
+++ b/src/main/java/me/kevinboone/jgemini/protocol/GeminiConnection.java
@@ -4,6 +4,7 @@ import java.io.*;
 import javax.net.ssl.*;
 import java.security.cert.X509Certificate;
 import java.net.*;
+import java.util.Collections;
 
 public class GeminiConnection extends URLConnection
   {
@@ -75,6 +76,9 @@ public class GeminiConnection extends URLConnection
       SSLContext sc = SSLContext.getInstance("SSL");
       sc.init (null, trustAllCerts, new java.security.SecureRandom());
       s = (SSLSocket)sc.getSocketFactory().createSocket (host, port); 
+      SSLParameters params = new SSLParameters();
+      params.setServerNames(Collections.singletonList(new SNIHostName(host)));
+      s.setSSLParameters(params);
       is = s.getInputStream();
       OutputStream os = s.getOutputStream();
       PrintStream pos = new PrintStream (os);


### PR DESCRIPTION
While developing a [bare-bone gemini client library](https://github.com/omar-polo/gemini) for clojure, I took a look at this implementation for things like accepting self-signed certs.  One thing that I noticed is that java doesn't seem to send SNI (server name indication) by default (FWIW I'm running `jdk-11.0.12.7.1v0`.)

The gemini specification requires SNI, and various servers will refuse to accept requests from clients that doesn't provide one.

This PR adds SNI to requests, I've tested locally against [gmid](https://gmid.omarpolo.com/) and seems to work.  I have still some problems to browse the geminispace using jgemini thought.

(I'm using the same code in [Request.java](https://github.com/omar-polo/gemini/blob/main/src/com/omarpolo/gemini/Request.java#L114) for my little library.)